### PR TITLE
Added ruby/jekyll link to setup instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -4,10 +4,20 @@ title: Setup
 permalink: /setup/
 ---
 
-Please see [this section of the workshop template][workshop-setup]
-for instructions on installing Git.
+## Prior to the workshop
 
-We'll do our work in the `Desktop` folder so make sure you change your working directory to it with:
+Please see [this section of the workshop template][workshop-setup]
+for instructions on installing Git.  Windows users should also 
+follow the instructions for installing the text editor as well.
+
+Once the above is completed users also need to install ruby and bundler.
+You can do so by following the directions in [the Requirements
+section of this webpage][ruby-jekyll-setup].
+
+## During the workshop:
+
+We'll do our work in the `Desktop` folder so make sure you
+change your working directory to it with:
 
 ~~~
 $ cd
@@ -16,3 +26,4 @@ $ cd Desktop
 {: .bash}
 
 [workshop-setup]: https://swcarpentry.github.io/workshop-template/#git
+[ruby-jekyll-setup]: https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#requirements


### PR DESCRIPTION
Added ruby/jekyll setup instructions to setup page.

I kept forgetting to test this when I had a windows computer at home. But I think in the email we should say that this is untested on windows so please try it asap and email us if you have problems.

All of them should try to install it prior to the workshop anyway to help with time.

Fixes #8 
